### PR TITLE
Allow configuring semantic batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ The hybrid setup is defined in `config.json`:
       "max_docs": 20000,
       "topk": 200,
       "weight_semantic": 0.65,
-      "weight_bm25": 0.35
+      "weight_bm25": 0.35,
+      "batch_size": 128
     },
     "parquet": {
       "max_files": 200,

--- a/config.json
+++ b/config.json
@@ -28,7 +28,8 @@
       "topk": 200,
       "weight_semantic": 0.65,
       "weight_bm25": 0.35,
-      "normalize_embeddings": true
+      "normalize_embeddings": true,
+      "batch_size": 128
     },
     "parquet": {
       "max_files": 200,

--- a/ddl_binder.py
+++ b/ddl_binder.py
@@ -858,7 +858,7 @@ class DDLEvidenceBinder:
             
             # Encode texts in batches with progress tracking
             normalize_embeddings = self.semantic_cfg.get("normalize_embeddings", True)
-            batch_size = 128  # Reasonable batch size for BGE-M3
+            batch_size = self.semantic_cfg.get("batch_size", 128)
             total_batches = (len(texts) + batch_size - 1) // batch_size
             
             embeddings_list = []


### PR DESCRIPTION
## Summary
- Support `batch_size` in semantic config
- Use configured batch size when building semantic index
- Document batch size option in README and sample config

## Testing
- ⚠️ `pytest -q` (hung on downloading models; interrupted)
- ✅ `pytest test_ddl_unit.py::TestParquetEngineGuards::test_missing_parquet_engine_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac73f20cf8832b9dbfaac33f074474