### PR TITLE
Enable semantic retrieval by default

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
   
   "binder": {
     "semantic": {
-      "enabled": false,
+      "enabled": true,
       "model_name": "BAAI/bge-m3",
       "index_cache_dir": "./.binder_index",
       "max_docs": 10000000,


### PR DESCRIPTION
## Summary
- enable semantic retrieval by default via binder.semantic.enabled in config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp'; AssertionError: Semantic enabled should have embedding model)*

------
https://chatgpt.com/codex/tasks/task_e_68ac73efe240832b9d024ea4e3ed7195