### PR TITLE
Improve HybridRetrievalSystem import handling

### DIFF
--- a/semantic_corpus_sampler.py
+++ b/semantic_corpus_sampler.py
@@ -9,9 +9,12 @@ from pathlib import Path
 
 try:
     from hybrid_retrieval_system import HybridRetrievalSystem
-except ImportError:
-    print("Warning: Could not import HybridRetrievalSystem - using fallback")
-    HybridRetrievalSystem = None
+except ImportError as e:
+    # Capture the original ImportError so missing module information is visible
+    print(f"Warning: Could not import HybridRetrievalSystem: {e}")
+    raise ImportError(
+        "HybridRetrievalSystem is required but could not be imported."
+    ) from e
 
 class SemanticCorpusConceptSampler:
     """


### PR DESCRIPTION
## Summary
- expose underlying ImportError when HybridRetrievalSystem import fails
- raise a clearer exception instead of falling back to `None`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named '...)`

------
https://chatgpt.com/codex/tasks/task_e_68ac7c19dd84832b8ec578442bbc882d