### PR TITLE
Raise error when retrieval system missing

### DIFF
--- a/semantic_corpus_sampler.py
+++ b/semantic_corpus_sampler.py
@@ -23,6 +23,11 @@ class SemanticCorpusConceptSampler:
         self.config = config or {}
         self.retrieval_system = None
         self.initialize_retrieval()
+        if self.retrieval_system is None:
+            raise RuntimeError(
+                "Failed to initialize retrieval system. "
+                "Please verify retrieval dependencies are installed and the retrieval class name is correct."
+            )
     
     def initialize_retrieval(self):
         """Initialize the hybrid retrieval system with existing indexes."""

--- a/semantic_ddl_pipeline.py
+++ b/semantic_ddl_pipeline.py
@@ -37,7 +37,13 @@ class SemanticDDLPipeline:
         )
         
         # Initialize semantic corpus sampler with config
-        self.corpus_sampler = SemanticCorpusConceptSampler(config=config)
+        try:
+            self.corpus_sampler = SemanticCorpusConceptSampler(config=config)
+        except RuntimeError as e:
+            raise RuntimeError(
+                "Failed to initialize semantic corpus sampler. "
+                "Please verify retrieval dependencies and class name."
+            ) from e
     
     def generate_concept_pairs(self, paper_text: str, target_pairs: int = 10) -> List[Dict[str, Any]]:
         """


### PR DESCRIPTION
## Summary
- throw RuntimeError if SemanticCorpusConceptSampler lacks retrieval system
- wrap sampler init in SemanticDDLPipeline to surface user-friendly message

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiohttp'; AssertionError: Semantic enabled should have embedding model)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7c1ae200832b8a98fdb34451c0ea