### PR TITLE
Allow configuring retrieval directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ The hybrid setup is defined in `config.json`:
 }
 ```
 
+The `directories` section of `config.json` can override where retrieval
+resources live:
+
+```json
+"directories": {
+  "corpus": "/path/to/chunked_corpus",
+  "index": "retrieval_indexes"
+}
+```
+If omitted, the sampler falls back to the repository's `chunked_corpus` and
+`retrieval_indexes` directories.
+
 ## Core Components
 
 ### Pipeline Scripts

--- a/config.json
+++ b/config.json
@@ -115,9 +115,10 @@
   
   "directories": {
     "input": "pipeline/input",
-    "output": "pipeline/output", 
+    "output": "pipeline/output",
     "working": "pipeline/working",
     "corpus": "/Users/willkirby/scrape 2/LW_scrape/chunked_corpus",
+    "index": "retrieval_indexes",
     "stage2": "stage2"
   },
   

--- a/semantic_ddl_pipeline.py
+++ b/semantic_ddl_pipeline.py
@@ -37,7 +37,12 @@ class SemanticDDLPipeline:
         )
         
         # Initialize semantic corpus sampler with config
-        self.corpus_sampler = SemanticCorpusConceptSampler(config=config)
+        dirs_cfg = config.get('directories', {})
+        self.corpus_sampler = SemanticCorpusConceptSampler(
+            config=config,
+            index_dir=dirs_cfg.get('index'),
+            corpus_dir=dirs_cfg.get('corpus'),
+        )
     
     def generate_concept_pairs(self, paper_text: str, target_pairs: int = 10) -> List[Dict[str, Any]]:
         """


### PR DESCRIPTION
## Summary
- Allow `SemanticCorpusConceptSampler` to accept optional `index_dir` and `corpus_dir` paths and load defaults from config
- Pass configured directories from `SemanticDDLPipeline`
- Document new `directories.index`/`directories.corpus` fields in config and README

## Testing
- `python -m pytest -q` *(fails: Semantic retrieval model requires external download)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7c1c4320832bab0ebc2178a2649f