### PR TITLE
Pass directories to corpus sampler

### DIFF
--- a/semantic_ddl_pipeline.py
+++ b/semantic_ddl_pipeline.py
@@ -37,8 +37,13 @@ class SemanticDDLPipeline:
         )
         
         # Initialize semantic corpus sampler with config
+        dirs_cfg = config.get('directories', {})
         try:
-            self.corpus_sampler = SemanticCorpusConceptSampler(config=config)
+            self.corpus_sampler = SemanticCorpusConceptSampler(
+                config=config,
+                index_dir=dirs_cfg.get('index'),
+                corpus_dir=dirs_cfg.get('corpus'),
+            )
         except RuntimeError as e:
             raise RuntimeError(
                 "Failed to initialize semantic corpus sampler. "


### PR DESCRIPTION
## Summary
- ensure SemanticDDLPipeline passes optional index and corpus directories to `SemanticCorpusConceptSampler`

## Testing
- `pytest -q`
- `pytest test_ddl_unit.py::TestSemanticEnableDisable::test_semantic_enabled_vs_disabled -q` *(fails: embedding model download returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7d990a10832b8f080ee35874bc6e