### PR TITLE
feat: add multi-scale backpacks for paper concepts

### DIFF
--- a/semantic_corpus_sampler.py
+++ b/semantic_corpus_sampler.py
@@ -105,7 +105,9 @@ class SemanticCorpusConceptSampler:
         
         for i, paper_concept in enumerate(paper_concepts):
             concept_name = paper_concept.get('concept', paper_concept.get('name', ''))
-            concept_backpack = paper_concept.get('backpack', '')
+            concept_backpack = (paper_concept.get('backpack_m') or
+                                 paper_concept.get('backpack_l') or
+                                 paper_concept.get('backpack_s') or '')
             
             print(f"  {i+1}/{len(paper_concepts)}: '{concept_name}'")
             

--- a/semantic_ddl_pipeline.py
+++ b/semantic_ddl_pipeline.py
@@ -211,9 +211,9 @@ class SemanticDDLPipeline:
         for key_term, enhancement in domain_enhancements.items():
             if key_term in concept_name:
                 # Add enhanced backpack context
-                original_backpack = concept.get('backpack', '')
+                original_backpack = (concept.get('backpack_m') or concept.get('backpack_l') or concept.get('backpack_s') or '')
                 if not original_backpack or len(original_backpack) < 50:
-                    concept['backpack'] = f"{original_backpack} {enhancement}".strip()
+                    concept['backpack_m'] = f"{original_backpack} {enhancement}".strip()
                 break
         
         return concept
@@ -254,7 +254,8 @@ class SemanticDDLPipeline:
             'paper_name': paper_concept['concept'],  # Compatibility with sampler
             'paper_anchor_exact': paper_concept.get('anchor_exact', paper_concept['concept']),
             'paper_anchor_alias': paper_concept.get('anchor_alias', paper_concept['concept']),
-            'paper_backpack': paper_concept.get('backpack', ''),
+            'paper_backpack': paper_concept.get('backpack_m') or paper_concept.get('backpack_l') or paper_concept.get('backpack_s') or '',
+            'paper_section_title': paper_concept.get('section_title', ''),
             
             # Corpus side - complete metadata for binder/critic stages 
             'corpus_concept': {


### PR DESCRIPTION
## Summary
- generate small, medium, and large context backpacks with section titles for each paper concept
- use multi-scale backpacks throughout semantic pairing
- plumb section titles and new backpacks into corpus search and pair construction

## Testing
- `pytest test_ddl_integration.py::TestAcceptanceThresholds::test_docs_based_acceptance -q`
- `pytest test_ddl_integration.py::TestAcceptanceThresholds::test_legacy_files_acceptance -q`
- `pytest test_ddl_integration.py::TestAcceptanceThresholds::test_rows_based_acceptance -q`
- `pytest test_ddl_unit.py::TestSemanticEnableDisable::test_semantic_enabled_vs_disabled -q` *(fails: Failed to load embedding model: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5954a688832bad9c570a4e0e3380