### PR TITLE
Ensure debug message prints before early return

### DIFF
--- a/semantic_corpus_sampler.py
+++ b/semantic_corpus_sampler.py
@@ -97,8 +97,9 @@ class SemanticCorpusConceptSampler:
         """
         if not self.retrieval_system:
             print("❌ No retrieval system available")
-            return []        print(f"🔍 Finding relevant corpus concepts for {len(paper_concepts)} paper concepts...")
-        
+            print(f"🔍 Finding relevant corpus concepts for {len(paper_concepts)} paper concepts...")
+            return []
+
         all_corpus_concepts = []
         
         for i, paper_concept in enumerate(paper_concepts):


### PR DESCRIPTION
## Summary
- Split combined return/print line in `find_relevant_corpus_concepts`
- Print search context message before returning when retrieval system is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68ad7fc73974832baa6922ac1144374f