### PR TITLE
Add explicit FAISS cache reuse flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ The hybrid setup is defined in `config.json`:
       "topk": 200,
       "weight_semantic": 0.65,
       "weight_bm25": 0.35,
-      "batch_size": 128
+      "batch_size": 128,
+      "force_cache_reuse": false
     },
     "parquet": {
       "max_files": 200,
@@ -101,6 +102,10 @@ The hybrid setup is defined in `config.json`:
   }
 }
 ```
+
+Enable `force_cache_reuse` to reuse a previously built FAISS index even when
+the corpus fingerprint changes. The flag defaults to `false` so callers must
+opt in explicitly if they want to skip rebuilding the semantic index.
 
 ## Core Components
 

--- a/config.json
+++ b/config.json
@@ -29,7 +29,8 @@
       "weight_semantic": 0.65,
       "weight_bm25": 0.35,
       "normalize_embeddings": true,
-      "batch_size": 128
+      "batch_size": 128,
+      "force_cache_reuse": false
     },
     "parquet": {
       "max_files": 200,

--- a/ddl_paper_only_pipeline.py
+++ b/ddl_paper_only_pipeline.py
@@ -60,8 +60,9 @@ def check_acceptance_criteria(accept_by: str, rows_min: int = 2000000, docs_min:
 
 # ---- top-level worker for spawn pickling (required for 'spawn' start) ----
 def _binding_worker_with_queue(queue, config: dict, accepted_daydreams: list, paper_text: str, run_id: str = None, run_dir: str = None, paper_id: str = None):
-    os.environ.setdefault('FAISS_FORCE_CACHE_REUSE', '1')
     from ddl_binder import DDLEvidenceBinder
+    # Explicit cache reuse opt-in via config
+    force_cache_reuse = config.get('binder', {}).get('semantic', {}).get('force_cache_reuse', False)
     # Use binding_llm config for evidence binding (faster Qwen 30B on Ollama)
     binding_config = config.get('binding_llm', config)
     binder = DDLEvidenceBinder(
@@ -71,7 +72,8 @@ def _binding_worker_with_queue(queue, config: dict, accepted_daydreams: list, pa
         model=binding_config['model'],
         config=config,
         run_id=run_id,
-        run_dir=run_dir
+        run_dir=run_dir,
+        force_cache_reuse=force_cache_reuse
     )
     
     # Set paper_id if provided


### PR DESCRIPTION
## Summary
- remove implicit FAISS cache reuse environment variable
- add `force_cache_reuse` option to `DDLEvidenceBinder` and pipeline
- document `force_cache_reuse` in config and README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad7fcc2824832b98d5ea9f5b24731f