### PR TITLE
Add review card schema and retrieval filtering

### DIFF
--- a/card_composer.py
+++ b/card_composer.py
@@ -1,0 +1,49 @@
+from review_schema import ReviewCard
+
+
+def render_review_card(card: ReviewCard) -> str:
+    lines = []
+    lines.append(f"**{card.paper_id} — Review Card**")
+    lines.append(f"**TL;DR:** {card.tl_dr}")
+    lines.append("")
+    lines.append(f"**Verdict:** {card.verdict}")
+    lines.append("")
+    if card.strengths:
+        lines.append("**Strengths**")
+        for s in card.strengths:
+            lines.append(f"* {s}")
+        lines.append("")
+    if card.weaknesses:
+        lines.append("**Weaknesses**")
+        for w in card.weaknesses:
+            lines.append(f"* {w}")
+        lines.append("")
+    if card.key_claims:
+        lines.append("**Key Claims**")
+        lines.append("| ID | Claim | Conf. | Paper Anchor | Corpus Anchor |")
+        lines.append("| -- | ----- | ----: | ------------ | ------------- |")
+        for cl in card.key_claims:
+            pq = cl.evidence.paper_quotes[0]
+            cq = cl.evidence.corpus_quotes[0]
+            lines.append(
+                f"| {cl.id} | {cl.statement} | {cl.confidence:.2f} | [Paper: {pq.locator}] | [Corpus: {cq.locator}] |"
+            )
+        lines.append("")
+    if card.suggested_experiments:
+        lines.append("**Suggested Experiments**")
+        lines.append("| ID | Goal | Setup | Success |")
+        lines.append("| -- | ---- | ----- | ------- |")
+        for ex in card.suggested_experiments:
+            lines.append(f"| {ex.id} | {ex.goal} | {ex.setup} | {ex.success_criteria} |")
+        lines.append("")
+    if card.related_work_gaps:
+        lines.append("**Related-work gaps**")
+        for g in card.related_work_gaps:
+            lines.append(f"* {g}")
+        lines.append("")
+    if card.open_questions:
+        lines.append("**Open Questions**")
+        for q in card.open_questions:
+            lines.append(f"* {q}")
+        lines.append("")
+    return "\n".join(lines)

--- a/config.json
+++ b/config.json
@@ -37,7 +37,12 @@
       "file_selection": "round_robin"
     }
   },
-  
+
+  "min_pairing_score": 0.38,
+  "require_entity_overlap": true,
+  "critic_drop_threshold": 0.4,
+  "modes": ["quick", "deep", "skeptic"],
+
   "corpus_path": "/Users/willkirby/scrape 2/LW_scrape/chunked_corpus/contextual_chunks_complete.parquet",
   
   "processing": {

--- a/narrative_composer.py
+++ b/narrative_composer.py
@@ -1,0 +1,8 @@
+from review_schema import ReviewCard
+
+
+def render_narrative(card: ReviewCard) -> str:
+    lines = ["### What to think about next"]
+    for claim in card.key_claims:
+        lines.append(f"- Reflect on {claim.id}: {claim.statement}")
+    return "\n".join(lines)

--- a/reranker.py
+++ b/reranker.py
@@ -1,0 +1,21 @@
+from typing import List, Tuple
+
+try:
+    from sentence_transformers import CrossEncoder
+except Exception:  # pragma: no cover - fallback when not available
+    CrossEncoder = None  # type: ignore
+
+
+class CrossEncoderReranker:
+    """Simple cross-encoder based reranker."""
+
+    def __init__(self, model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"):
+        self.model = CrossEncoder(model_name) if CrossEncoder else None
+
+    def rerank(self, query: str, docs: List[Tuple[str, str]]) -> List[Tuple[str, float]]:
+        if not self.model:
+            # Fallback: keep original order with zero scores
+            return [(doc_id, 0.0) for doc_id, _ in docs]
+        pairs = [[query, text] for _, text in docs]
+        scores = self.model.predict(pairs)
+        return [(doc_id, float(score)) for (doc_id, _), score in zip(docs, scores)]

--- a/review_schema.py
+++ b/review_schema.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel, Field
+from typing import List, Literal, Optional
+
+class Quote(BaseModel):
+    source: Literal["paper", "corpus"]
+    doc_id: str
+    locator: str
+    text: str
+
+class Evidence(BaseModel):
+    paper_quotes: List[Quote] = Field(default_factory=list)
+    corpus_quotes: List[Quote] = Field(default_factory=list)
+    coverage_score: float
+
+class Claim(BaseModel):
+    id: str
+    statement: str
+    importance: Literal["low", "med", "high"]
+    confidence: float
+    evidence: Evidence
+    risks: List[str] = Field(default_factory=list)
+
+class Experiment(BaseModel):
+    id: str
+    goal: str
+    setup: str
+    success_criteria: str
+    blockers: List[str] = Field(default_factory=list)
+
+class ReviewCard(BaseModel):
+    paper_id: str
+    tl_dr: str
+    verdict: Literal["accept", "weak accept", "borderline", "weak reject", "reject"]
+    strengths: List[str] = Field(default_factory=list)
+    weaknesses: List[str] = Field(default_factory=list)
+    key_claims: List[Claim] = Field(default_factory=list)
+    suggested_experiments: List[Experiment] = Field(default_factory=list)
+    related_work_gaps: List[str] = Field(default_factory=list)
+    open_questions: List[str] = Field(default_factory=list)
+    confidence_calibration: str

--- a/test_composer_render.py
+++ b/test_composer_render.py
@@ -1,0 +1,24 @@
+from review_schema import ReviewCard, Claim, Evidence, Quote, Experiment
+from card_composer import render_review_card
+
+def test_markdown_contains_anchors_and_table():
+    pq = Quote(source="paper", doc_id="paper.pdf", locator="p.1 §1", text="paper quote")
+    cq = Quote(source="corpus", doc_id="corpus.txt", locator="§2", text="corpus quote")
+    ev = Evidence(paper_quotes=[pq], corpus_quotes=[cq], coverage_score=1.0)
+    claim = Claim(id="C1", statement="Test claim", importance="high", confidence=0.9, evidence=ev, risks=[])
+    card = ReviewCard(
+        paper_id="paper-1",
+        tl_dr="summary",
+        verdict="accept",
+        strengths=["good"],
+        weaknesses=["bad"],
+        key_claims=[claim],
+        suggested_experiments=[Experiment(id="E1", goal="goal", setup="setup", success_criteria="pass")],
+        related_work_gaps=["gap"],
+        open_questions=["question"],
+        confidence_calibration="because",
+    )
+    md = render_review_card(card)
+    assert "| ID | Claim" in md
+    assert "[Paper: p.1 §1]" in md
+    assert "[Corpus: §2]" in md

--- a/test_pairing_thresholds.py
+++ b/test_pairing_thresholds.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+from semantic_corpus_sampler import filter_candidates
+
+
+def make_result(doc_id, content, score):
+    return SimpleNamespace(doc_id=doc_id, content=content, combined_score=score)
+
+
+def test_filters_apply():
+    config = {
+        "min_pairing_score": 0.38,
+        "domain_whitelist": ["arxiv.org"],
+        "require_entity_overlap": True,
+    }
+    results = [
+        make_result("http://arxiv.org/abs/1", "alignment study", 0.5),
+        make_result("http://example.com/1", "alignment study", 0.6),
+        make_result("http://arxiv.org/abs/2", "random text", 0.7),
+        make_result("http://arxiv.org/abs/3", "alignment study", 0.1),
+    ]
+    filtered = filter_candidates(results, config, "alignment research")
+    assert len(filtered) == 1
+    assert filtered[0].doc_id.endswith("/1")

--- a/test_schema_validation.py
+++ b/test_schema_validation.py
@@ -1,0 +1,32 @@
+import pytest
+from validators import validate_review_card
+
+
+def test_missing_quotes_fails():
+    data = {
+        "paper_id": "P1",
+        "tl_dr": "test",
+        "verdict": "reject",
+        "strengths": [],
+        "weaknesses": [],
+        "key_claims": [
+            {
+                "id": "C1",
+                "statement": "claim",
+                "importance": "low",
+                "confidence": 0.5,
+                "evidence": {
+                    "paper_quotes": [],
+                    "corpus_quotes": [],
+                    "coverage_score": 0.0,
+                },
+                "risks": [],
+            }
+        ],
+        "suggested_experiments": [],
+        "related_work_gaps": [],
+        "open_questions": [],
+        "confidence_calibration": "",
+    }
+    with pytest.raises(Exception):
+        validate_review_card(data)

--- a/validators.py
+++ b/validators.py
@@ -1,0 +1,22 @@
+from typing import Dict
+from pydantic import ValidationError
+from review_schema import ReviewCard
+
+
+def validate_review_card(data: Dict) -> ReviewCard:
+    """Validate dict against ReviewCard schema and ensure evidence coverage."""
+    card = ReviewCard(**data)
+    for claim in card.key_claims:
+        if not claim.evidence.paper_quotes or not claim.evidence.corpus_quotes:
+            raise ValueError(f"Claim {claim.id} missing required quotes")
+    return card
+
+
+def coverage(card: ReviewCard) -> float:
+    """Compute fraction of claims with both paper and corpus quotes."""
+    if not card.key_claims:
+        return 0.0
+    supported = sum(
+        1 for c in card.key_claims if c.evidence.paper_quotes and c.evidence.corpus_quotes
+    )
+    return supported / len(card.key_claims)


### PR DESCRIPTION
## Summary
- add `ReviewCard` typed schema with quotes, claims, experiments
- template-based composer for review cards and narrative helper
- cross-encoder reranker and domain/score/entity filters in retrieval
- config adds pairing thresholds, entity overlap flag, and critic drop threshold
- basic validators and tests for schema, filtering, and rendering

## Testing
- `pytest test_schema_validation.py test_pairing_thresholds.py test_composer_render.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeccd673d0832b8a7bfe52eaf598f5